### PR TITLE
fixed: change coefficent to a big-endian integer

### DIFF
--- a/decomposer.go
+++ b/decomposer.go
@@ -30,7 +30,7 @@ func (f Fixed) Decompose(buf []byte) (form byte, negative bool, coefficient []by
 	} else {
 		coefficient = make([]byte, 8)
 	}
-	binary.LittleEndian.PutUint64(coefficient, uint64(c))
+	binary.BigEndian.PutUint64(coefficient, uint64(c))
 	exponent = -nPlaces
 	return
 }
@@ -57,7 +57,9 @@ func (f *Fixed) Compose(form byte, negative bool, coefficient []byte, exponent i
 	// Finite form.
 
 	var c uint64
-	for i, v := range coefficient {
+	maxi := len(coefficient) - 1
+	for i := range coefficient {
+		v := coefficient[maxi-i]
 		if i < 8 {
 			c |= uint64(v) << (uint(i) * 8)
 		} else if v != 0 {

--- a/decomposer_test.go
+++ b/decomposer_test.go
@@ -48,13 +48,14 @@ func TestDecomposerCompose(t *testing.T) {
 		Err bool // Expect an error.
 	}{
 		{N: "Zero", S: "0", Coef: nil, Exp: 0},
-		{N: "Normal-1", S: "123.456", Coef: []byte{0x40, 0xE2, 0x01}, Exp: -3},
-		{N: "Neg-1", S: "-123.456", Neg: true, Coef: []byte{0x40, 0xE2, 0x01}, Exp: -3},
-		{N: "PosExp-1", S: "123456000", Coef: []byte{0x40, 0xE2, 0x01}, Exp: 3},
-		{N: "PosExp-2", S: "-123456000", Neg: true, Coef: []byte{0x40, 0xE2, 0x01}, Exp: 3},
-		{N: "AllDec-1", S: "0.123456", Coef: []byte{0x40, 0xE2, 0x01}, Exp: -6},
-		{N: "AllDec-2", S: "-0.123456", Neg: true, Coef: []byte{0x40, 0xE2, 0x01}, Exp: -6},
-		{N: "TooSmall-1", S: "-0.00123456", Neg: true, Coef: []byte{0x40, 0xE2, 0x01}, Exp: -8, Err: true},
+		{N: "Normal-1", S: "123.456", Coef: []byte{0x01, 0xE2, 0x40}, Exp: -3},
+		{N: "Neg-1", S: "-123.456", Neg: true, Coef: []byte{0x01, 0xE2, 0x40}, Exp: -3},
+		{N: "PosExp-1", S: "123456000", Coef: []byte{0x01, 0xE2, 0x40}, Exp: 3},
+		{N: "PosExp-2", S: "-123456000", Neg: true, Coef: []byte{0x01, 0xE2, 0x40}, Exp: 3},
+		{N: "AllDec-1", S: "0.123456", Coef: []byte{0x01, 0xE2, 0x40}, Exp: -6},
+		{N: "AllDec-2", S: "-0.123456", Neg: true, Coef: []byte{0x01, 0xE2, 0x40}, Exp: -6},
+		{N: "TooSmall-1", S: "-0.00123456", Neg: true, Coef: []byte{0x01, 0xE2, 0x40}, Exp: -8, Err: true},
+		{N: "LeadingZero-1", S: "123.456", Coef: []byte{0, 0, 0, 0, 0, 0, 0, 0x01, 0xE2, 0x40}, Exp: -3},
 		{N: "NaN-1", S: "NaN", Form: 2},
 	}
 


### PR DESCRIPTION
Three popular arbitrary length decimal packages use big.Int
which has a big-endian Bytes and SetBytes method. Changing the
definition to big-endian will reduce the work in those cases
and for fixed length decimals will be different, but no more
expensive.