### PR TITLE
made implementation of decomposer.Decimal interface optional for compatibility with SQLite driver

### DIFF
--- a/decomposer.go
+++ b/decomposer.go
@@ -1,3 +1,6 @@
+//go:build !sql_scanner
+// +build !sql_scanner
+
 package fixed
 
 import (

--- a/decomposer_test.go
+++ b/decomposer_test.go
@@ -1,3 +1,6 @@
+//go:build !sql_scanner
+// +build !sql_scanner
+
 package fixed
 
 import (

--- a/readme.md
+++ b/readme.md
@@ -55,3 +55,9 @@ BenchmarkWriteTo-2          	20000000	        69.9 ns/op	      27 B/op	       0 
 </pre>
 
 The "decimal" above is the common [shopspring decimal](https://github.com/shopspring/decimal) library
+
+**Compatibility with SQL drivers**
+
+By default `Fixed` implements `decomposer.Decimal` interface for database
+drivers that support it. To use `sql.Scanner` and `driver.Valuer`
+implementation flag `sql_scanner` must be specified on build.

--- a/sql.go
+++ b/sql.go
@@ -1,0 +1,67 @@
+//go:build sql_scanner
+// +build sql_scanner
+
+package fixed
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Scan implements the sql.Scanner interface for database deserialization.
+func (f *Fixed) Scan(value interface{}) error {
+	// first try to see if the data is stored in database as a Numeric datatype
+	switch v := value.(type) {
+
+	case float32:
+		*f = NewF(float64(v))
+		return nil
+
+	case float64:
+		// numeric in sqlite3 sends us float64
+		*f = NewF(v)
+		return nil
+
+	case int64:
+		*f = NewI(v, nPlaces)
+		return nil
+
+	default:
+		// default is trying to interpret value stored as string
+		str, err := unquoteIfQuoted(v)
+		if err != nil {
+			return err
+		}
+		val, err := NewSErr(str)
+		if err != nil {
+			return err
+		}
+		*f = val
+		return nil
+	}
+}
+
+func unquoteIfQuoted(value interface{}) (string, error) {
+	var bytes []byte
+
+	switch v := value.(type) {
+	case string:
+		bytes = []byte(v)
+	case []byte:
+		bytes = v
+	default:
+		return "", fmt.Errorf("could not convert value '%+v' to byte array of type '%T'",
+			value, value)
+	}
+
+	// If the amount is quoted, strip the quotes
+	if len(bytes) > 2 && bytes[0] == '"' && bytes[len(bytes)-1] == '"' {
+		bytes = bytes[1 : len(bytes)-1]
+	}
+	return string(bytes), nil
+}
+
+// Value implements the driver.Valuer interface for database serialization.
+func (f Fixed) Value() (driver.Value, error) {
+	return f.String(), nil
+}

--- a/sql_test.go
+++ b/sql_test.go
@@ -1,0 +1,54 @@
+//go:build sql_scanner
+// +build sql_scanner
+
+package fixed
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestSQL(t *testing.T) {
+	// open a database
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// close the database at the end of the function
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS "test" ("id" INTEGER, "value" BLOB, PRIMARY KEY("id"))`); err != nil {
+		t.Fatal(err)
+	}
+	v := NewF(1.2345)
+	_, err = db.Exec("insert into test (value) values (?);", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get the customer record
+	rows, err := db.Query("select value from test;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// close the rows at the end of the function
+	defer rows.Close()
+	var foundVal Fixed
+	for rows.Next() {
+		if err := rows.Scan(
+			&foundVal,
+		); err != nil {
+			t.Fatal(err)
+		}
+		t.Log(foundVal)
+		break
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if foundVal.String() != v.String() {
+		t.Error("should be equal", foundVal.String(), v.String())
+	}
+}


### PR DESCRIPTION
Hi there. There was some trouble to make it work with SQLite, it appears that in some cases plain sql.Scanner implementation works and decomposer.Decimal - does not.